### PR TITLE
Issue 2 commons app language

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/settings/SettingsFragment.java
@@ -136,7 +136,33 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
         // Gets current language code from shared preferences
         String languageCode;
-
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            // **Added:** Disable the app's UI language preference for Android 13 and above
+            appUiLanguageListPreference.setEnabled(false);
+            appUiLanguageListPreference.setSummary(getString(R.string.use_system_language));
+        } else {
+            // **Existing code remains for older Android versions**
+            keyLanguageListPreference = appUiLanguageListPreference.getKey();
+            languageCode = getCurrentLanguageCode(keyLanguageListPreference);
+            assert languageCode != null;
+            if (languageCode.equals("")) {
+                // If current language code is empty, means none selected by user yet so use phone local
+                appUiLanguageListPreference.setSummary(Locale.getDefault().getDisplayLanguage());
+            } else {
+                // If any language is selected by user previously, use it
+                Locale defLocale = createLocale(languageCode);
+                appUiLanguageListPreference.setSummary(defLocale.getDisplayLanguage(defLocale));
+            }
+            appUiLanguageListPreference.setOnPreferenceClickListener(new OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    // **No change:** Existing method call
+                    prepareAppLanguages(appUiLanguageListPreference.getKey());
+                    return true;
+                }
+            });
+        }
+/*
         appUiLanguageListPreference = findPreference("appUiDefaultLanguagePref");
         assert appUiLanguageListPreference != null;
         keyLanguageListPreference = appUiLanguageListPreference.getKey();
@@ -159,6 +185,9 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             }
         });
 
+ */
+
+        // Continue with other preferences
         descriptionLanguageListPreference = findPreference("descriptionDefaultLanguagePref");
         assert descriptionLanguageListPreference != null;
         keyLanguageListPreference = descriptionLanguageListPreference.getKey();
@@ -311,6 +340,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         HashMap<Integer, String> selectedLanguages = new HashMap<>();
 
         if (keyListPreference.equals("appUiDefaultLanguagePref")) {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                // For Android 13+, the system manages language, so we skip manual selection
+                return;
+            }
 
             assert languageCode != null;
             if (languageCode.equals("")) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
   <string name="nearby_filter_search">Search View</string>
   <string name="nearby_filter_state">Place State</string>
   <string name="appwidget_img">Pic of the Day</string>
+  <string name="use_system_language">Using system language</string>
 
   <!--Other strings-->
   <plurals name="uploads_pending_notification_indicator">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -12,7 +12,9 @@
             android:entries="@array/pref_theme_entries"
             android:entryValues="@array/pref_theme_entries_values"
             app:useSimpleSummaryProvider="true"
-            android:defaultValue="0" />
+          android:dependency="is_below_android_13"
+          android:defaultValue="0" />
+
 
     </PreferenceCategory>
 

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -23,7 +23,7 @@ WHERE {
   BIND(COALESCE(?itemLabelPreferredLanguage, ?itemLabelAnyLanguage, "?") as ?label)
 
   # Get the description in the preferred language of the user, or any other language if no description is available in that language.
-  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (lang(?itemDescriptionPreferredLanguage) = "${LANG}")}
+  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (LANG(?itemDescriptionPreferredLanguage) = "${LANG}" || LANG(?itemDescriptionPreferredLanguage) = "en")}
   OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage}
   BIND(COALESCE(?itemDescriptionPreferredLanguage, ?itemDescriptionAnyLanguage, "?") as ?description)
 

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -23,6 +23,7 @@ WHERE {
   BIND(COALESCE(?itemLabelPreferredLanguage, ?itemLabelAnyLanguage, "?") as ?label)
 
   # Get the description in the preferred language of the user, or any other language if no description is available in that language.
+  # This ensures that the query first tries to fetch the label in the user's preferred language, and if it's unavailable, it falls back to English
   OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (LANG(?itemDescriptionPreferredLanguage) = "${LANG}" || LANG(?itemDescriptionPreferredLanguage) = "en")}
   OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage}
   BIND(COALESCE(?itemDescriptionPreferredLanguage, ?itemDescriptionAnyLanguage, "?") as ?description)

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -23,8 +23,8 @@ WHERE {
   BIND(COALESCE(?itemLabelPreferredLanguage, ?itemLabelAnyLanguage, "?") as ?label)
 
   # Get the description in the preferred language of the user, or any other language if no description is available in that language.
-  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (}
-  OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage}LANG(?itemDescriptionPreferredLanguage) = "${LANG}" || LANG(?itemDescriptionPreferredLanguage) = "en"
+  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (LANG(?itemDescriptionPreferredLanguage) = "${LANG}" || LANG(?itemDescriptionPreferredLanguage) = "en")}
+  OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage}
   BIND(COALESCE(?itemDescriptionPreferredLanguage, ?itemDescriptionAnyLanguage, "?") as ?description)
 
   # Get the class label in the preferred language of the user, or any other language if no label is available in that language.

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -23,8 +23,8 @@ WHERE {
   BIND(COALESCE(?itemLabelPreferredLanguage, ?itemLabelAnyLanguage, "?") as ?label)
 
   # Get the description in the preferred language of the user, or any other language if no description is available in that language.
-  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (LANG(?itemDescriptionPreferredLanguage) = "${LANG}" || LANG(?itemDescriptionPreferredLanguage) = "en"}
-  OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage}
+  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (}
+  OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage}LANG(?itemDescriptionPreferredLanguage) = "${LANG}" || LANG(?itemDescriptionPreferredLanguage) = "en"
   BIND(COALESCE(?itemDescriptionPreferredLanguage, ?itemDescriptionAnyLanguage, "?") as ?description)
 
   # Get the class label in the preferred language of the user, or any other language if no label is available in that language.

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -23,7 +23,7 @@ WHERE {
   BIND(COALESCE(?itemLabelPreferredLanguage, ?itemLabelAnyLanguage, "?") as ?label)
 
   # Get the description in the preferred language of the user, or any other language if no description is available in that language.
-  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (lang(?itemDescriptionPreferredLanguage) = "${LANG}")}
+  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (LANG(?itemDescriptionPreferredLanguage) = "${LANG}" || LANG(?itemDescriptionPreferredLanguage) = "en"}
   OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage}
   BIND(COALESCE(?itemDescriptionPreferredLanguage, ?itemDescriptionAnyLanguage, "?") as ?description)
 

--- a/app/src/main/resources/queries/query_for_item.rq
+++ b/app/src/main/resources/queries/query_for_item.rq
@@ -23,7 +23,7 @@ WHERE {
   BIND(COALESCE(?itemLabelPreferredLanguage, ?itemLabelAnyLanguage, "?") as ?label)
 
   # Get the description in the preferred language of the user, or any other language if no description is available in that language.
-  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (LANG(?itemDescriptionPreferredLanguage) = "${LANG}" || LANG(?itemDescriptionPreferredLanguage) = "en")}
+  OPTIONAL {?item schema:description ?itemDescriptionPreferredLanguage. FILTER (lang(?itemDescriptionPreferredLanguage) = "${LANG}")}
   OPTIONAL {?item schema:description ?itemDescriptionAnyLanguage}
   BIND(COALESCE(?itemDescriptionPreferredLanguage, ?itemDescriptionAnyLanguage, "?") as ?description)
 


### PR DESCRIPTION
Fix: Handle system-level language management for Android 13+ (API 33)
- Added a check in `prepareAppLanguages()` to skip manual UI language selection for Android 13+ where the system manages app language.
- Updated logic to ensure that the language selection dialog is shown only for devices running Android versions below API 33.
- Retained existing logic for description and secondary language preferences.
